### PR TITLE
participation merge fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ AllCops:
 Style/CaseLikeIf:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 110
 
 Metrics/AbcSize:
@@ -56,6 +56,9 @@ Style/GuardClause:
 
 Layout/IndentationWidth:
   Width: 2
+
+Layout/EndOfLine:
+  Enabled: False
 
 Naming/ClassAndModuleCamelCase:
   Enabled: true

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,6 @@
 class EventsController < ApplicationController
   def index
-    member = Member.find_by(uid: cookies[:current_member_id])
-    @my_events = member.events
+    @my_events = current_member.events
 
     ordered = Event.order(:datetime)
 
@@ -80,17 +79,15 @@ class EventsController < ApplicationController
 
   def attend
     @event = Event.find(params[:id])
-    member = Member.find_by(uid: cookies[:current_member_id])
-    member.events << @event
-    member.save
+    current_member.events << @event
+    current_member.save
     redirect_to(events_path)
   end
 
   def unattend
     @event = Event.find(params[:id])
-    member = Member.find_by(uid: cookies[:current_member_id])
-    member.events.delete(@event)
-    member.save
+    current_member.events.delete(@event)
+    current_member.save
     redirect_to(events_path)
   end
 

--- a/app/controllers/members/omniauth_callbacks_controller.rb
+++ b/app/controllers/members/omniauth_callbacks_controller.rb
@@ -3,7 +3,7 @@
 class Members::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
     member = Member.from_google(**from_google_params)
-    cookies[:current_member_id] = auth.uid
+
     if member.present?
       sign_out_all_scopes
       flash[:success] = t 'devise.omniauth_callbacks.success', kind: 'Google'

--- a/app/controllers/point_tracker_controller.rb
+++ b/app/controllers/point_tracker_controller.rb
@@ -2,7 +2,13 @@ class PointTrackerController < ApplicationController
   def tracker
     redirect_to point_tracker_admin_url if current_member.isAdmin
 
-    @events = Event.all
+    @mandatory_event_num = Event.where(isMandatory: true).where('datetime < ?', Time.zone.now).length
+    @member_mandatory_event_num = current_member.events.where(isMandatory: true).where('datetime < ?',
+                                                                                       Time.zone.now).length
+
+    ordered = Event.order(:datetime)
+    @upcoming_events = ordered.where('datetime > ? or datetime IS NULL', Time.zone.now).limit(5)
+
     @service_hours = Service.where(member_id: current_member.id).order('date desc')
   end
 
@@ -10,6 +16,8 @@ class PointTrackerController < ApplicationController
     redirect_to root_path unless current_member.isAdmin
 
     @events = Event.all
+    @mandatory_event_num = Event.where(isMandatory: true).where('datetime < ?', Time.zone.now).length
+    @event_num = Event.where('datetime < ?', Time.zone.now).length
     @members = Member.all
     @service_hours = Service.all
     Rails.logger.debug 'Service is in admin view'

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,8 +7,7 @@ class Member < ApplicationRecord
 
     return nil if Whitelist.find_by(email: email).nil?
 
-    create_with(uid: uid, name: full_name, email: email,
-                isAdmin: Whitelist.find_by(email: email).isAdmin).find_or_create_by!(uid: uid)
+    create_with(uid: uid, name: full_name, email: email, isAdmin: false).find_or_create_by!(uid: uid)
   end
 
   def sort_service

--- a/app/views/point_tracker/admin.html.erb
+++ b/app/views/point_tracker/admin.html.erb
@@ -6,13 +6,15 @@
 <br/>
 
 <div class="mt-5 container home index">
-<h2>Service Hours:</h3>
-<table class="mt-3 table listing">
+<h2>Member Participation:</h3>
+<table id="ParticipationTable" class="mt-3 table listing">
   <thead>
     <tr>
       <th>Member</th>
-      <th>Approved Service Hours</th>
-      <th>Unapproved Service Hours</th>
+      <th onclick="sortTable(1)">Approved Service Hours</th>
+      <th onclick="sortTable(2)">Unapproved Service Hours</th>
+      <th onclick="sortTable(3)">Attendance Percentage</th>
+      <th onclick="sortTable(4)">Missed Mandatory Events</th>
     </tr>
   </thead>
   <tbody>
@@ -21,7 +23,12 @@
         <td><%= member.name %></td>
         <td><%= @service_hours.where(member_id: member.id, isApproved: true,).sum(:hours) %></td>
         <td><%= @service_hours.where(member_id: member.id, isApproved: false).sum(:hours) %></td>
-
+        <% if @event_num > 0 %>
+          <td><%= 100*member.events.where('datetime < ?', Time.now).length / @event_num %></td>
+        <% else %>
+          <td><%= 100 %></td>
+        <% end %>
+        <td><%= @mandatory_event_num - member.events.where(isMandatory: true).where('datetime < ?', Time.now).length %></td>
       </tr>
     <% end %>
   </tbody>
@@ -29,26 +36,57 @@
 
 </div>
 
-<div class="mt-5 container home index">
-<h2>Events: </h2>
-<table class="mt-3 table listing">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Date</th>
-      <th>Mandatory</th>
-      <th>Head Count</th>
-    </tr>
-  </thead>  
-  <tbody>
-    <% @events.each do |event| %>
-      <tr>
-        <td><%= event.name %></td>
-        <td><%= event.format_date %></td>
-        <td><%= event.isMandatory%></td>
-        <td><%= event.members.count%></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
-</div>
+<script>
+function sortTable(n) {
+  var table, rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+  table = document.getElementById("ParticipationTable");
+  switching = true;
+  // Set the sorting direction to ascending:
+  dir = "asc";
+  /* Make a loop that will continue until
+  no switching has been done: */
+  while (switching) {
+    // Start by saying: no switching is done:
+    switching = false;
+    rows = table.rows;
+    /* Loop through all table rows (except the
+    first, which contains table headers): */
+    for (i = 1; i < (rows.length - 1); i++) {
+      // Start by saying there should be no switching:
+      shouldSwitch = false;
+      /* Get the two elements you want to compare,
+      one from current row and one from the next: */
+      x = rows[i].getElementsByTagName("TD")[n];
+      y = rows[i + 1].getElementsByTagName("TD")[n];
+      /* Check if the two rows should switch place,
+      based on the direction, asc or desc: */
+      if (dir == "asc") {
+        if (Number(x.innerHTML) > Number(y.innerHTML)) {
+          shouldSwitch = true;
+          break;
+        }
+      } else if (dir == "desc") {
+        if (Number(x.innerHTML) < Number(y.innerHTML)) {
+          shouldSwitch = true;
+          break;
+        }
+      }
+    }
+    if (shouldSwitch) {
+      /* If a switch has been marked, make the switch
+      and mark that a switch has been done: */
+      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+      switching = true;
+      // Each time a switch is done, increase this count by 1:
+      switchcount ++;
+    } else {
+      /* If no switching has been done AND the direction is "asc",
+      set the direction to "desc" and run the while loop again. */
+      if (switchcount == 0 && dir == "asc") {
+        dir = "desc";
+        switching = true;
+      }
+    }
+  }
+}
+</script>

--- a/app/views/point_tracker/tracker.html.erb
+++ b/app/views/point_tracker/tracker.html.erb
@@ -33,20 +33,22 @@
 </div>
 
 <div class="mt-5 container home index">
-<h2>Events: </h2>
+<h2>Events: <%= @member_mandatory_event_num %> / <%=@mandatory_event_num %> mandatory events attended</h2>
 <table class="mt-3 table listing">
   <thead>
     <tr>
       <th>Name</th>
       <th>Date</th>
+      <th>Description</th>
       <th>Mandatory</th>
     </tr>
   </thead>  
   <tbody>
-    <% @current_member.events.each do |event| %>
+    <% @upcoming_events.each do |event| %>
       <tr>
         <td><%= event.name %></td>
         <td><%= event.format_date %></td>
+        <td><%= event.description %></td>
         <td><%= event.isMandatory%></td>
       </tr>
     <% end %>

--- a/app/views/whitelists/_form.html.erb
+++ b/app/views/whitelists/_form.html.erb
@@ -8,11 +8,6 @@
             <%= f.label :email, {class: "form-label"} %>
             <%= f.text_field :email, {class: "form-control", required: true} %>
           </div>
-
-          <div class="mb-2">
-            <%= f.label "User is an Admin", {class: "form-label"} %>
-            <%= f.check_box :isAdmin, {class: "form-check-label"} %>
-          </div>
         </div>
     </div>
 

--- a/app/views/whitelists/_table.html.erb
+++ b/app/views/whitelists/_table.html.erb
@@ -2,15 +2,12 @@
   <table class="mt-3 table listing" summary="Whitelist">
     <tr class="header">
       <th>Email</th>
-      <th>Admin</th>
     </tr>
     <% users.each do |user| %>
     <tr>
       <td><%= user.email %></td>
-      <td><%= user.isAdmin %></td>
 
       <td>
-        <div><%= link_to("Make Admin", edit_whitelist_path(user), :class => 'action edit') %></div>
         <div><%= link_to("Delete", delete_whitelist_path(user), :class => 'action delete') %></div>
       </td>
     </tr>

--- a/db/migrate/20211111014240_remove_admin_from_whitelist.rb
+++ b/db/migrate/20211111014240_remove_admin_from_whitelist.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromWhitelist < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :whitelists, :isAdmin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_23_190032) do
+ActiveRecord::Schema.define(version: 2021_11_11_014240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 2021_10_23_190032) do
 
   create_table "whitelists", force: :cascade do |t|
     t.string "email", null: false
-    t.boolean "isAdmin"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,18 +7,20 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 whitelist_data = [
-  ['paul-b-tamu@tamu.edu', false],
-  ['centurymens.social@gmail.com', true],
-  ['ammar918@gmail.com', true],
-  ['siddiqi918@tamu.edu', false],
-  ['siddiqi91899@gmail.com', false],
-  ['deananderson@tamu.edu', false],
-  ['andersondeant@gmail.com', true],
-  ['mivoli98@tamu.edu', false],
-  ['mibeophi2@gmail.com', true]
-
+  'paul-b-tamu@tamu.edu',
+  'centurymens.social@gmail.com',
+  'ammar918@gmail.com',
+  'siddiqi918@tamu.edu',
+  'siddiqi91899@gmail.com',
+  'deananderson@tamu.edu',
+  'andersondeant@gmail.com',
+  'mivoli98@tamu.edu',
+  'mibeophi2@gmail.com'
 ]
 
-whitelist_data.each do |email, isAdmin|
-  Whitelist.create(email: email, isAdmin: isAdmin)
+whitelist_data.each do |email|
+  Whitelist.create(email: email) if Whitelist.find_by(email: email).nil?
 end
+
+Member.create(name: 'Dean Anderson', isAdmin: true, email: 'andersondeant@gmail.com', 
+  uid: 114113468747151673770) if Member.find_by(uid: 114113468747151673770).nil?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,23 +79,35 @@ end
 
 def force_white_list
   whitelist_data = [
-    ['paul-b-tamu@tamu.edu', false],
-    ['centurymens.social@gmail.com', true],
-    ['ammar918@gmail.com', true],
-    ['siddiqi918@tamu.edu', false],
-    ['siddiqi91899@gmail.com', false],
-    ['deananderson@tamu.edu', false],
-    ['andersondeant@gmail.com', true],
-    ['mivoli98@tamu.edu', false],
-    ['mibeophi2@gmail.com', true]
-
+    'paul-b-tamu@tamu.edu',
+    'centurymens.social@gmail.com',
+    'ammar918@gmail.com',
+    'siddiqi918@tamu.edu',
+    'siddiqi91899@gmail.com',
+    'deananderson@tamu.edu',
+    'andersondeant@gmail.com',
+    'mivoli98@tamu.edu',
+    'mibeophi2@gmail.com'
   ]
 
-  whitelist_data.each do |email, admin|
-    Whitelist.create(email: email, isAdmin: admin) if Whitelist.find_by(email: email).nil?
+  whitelist_data.each do |email|
+    Whitelist.create(email: email) if Whitelist.find_by(email: email).nil?
   end
 
   tp Whitelist.all
+end
+
+def force_members
+  if Member.find_by(uid: 12_345_678_910).nil?
+    Member.create(name: 'Ammar Siddiqi', isAdmin: true, email: 'ammar918@gmail.com',
+                  uid: 12_345_678_910)
+  end
+  if Member.find_by(uid: 12_345_678_919).nil?
+    Member.create(name: 'Paul Paul', isAdmin: false, email: 'paul-b-tamu@tamu.edu',
+                  uid: 12_345_678_919)
+  end
+
+  tp Member.all
 end
 
 def use_admin
@@ -113,7 +125,7 @@ end
 def use_user
   OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
                                                                        provider: 'google_oauth2',
-                                                                       uid: '12345678910',
+                                                                       uid: '12345678919',
                                                                        info: {
                                                                          email: 'paul-b-tamu@tamu.edu',
                                                                          first_name: 'Paul',
@@ -125,3 +137,4 @@ end
 OmniAuth.config.test_mode = true
 use_admin
 force_white_list
+force_members


### PR DESCRIPTION
Admin: View of all members, should be able to sort the users based on the table headers (except member name). Can't test this because I need more users so I'm not sure how to test if it works
Member: Added 5 upcoming events and number of mandatory meetings they've attended / total

*All information listed about events on the web page is about past events to track participation up to this point

Description:
As a user, I want to see a summary of my participation and upcoming events, so that I can be sure I’m not falling behind.

Definition of Done:
Percent of mandatory meetings is displayed. 5 next events listed below clearly.

Acceptance Criteria:
The home page should show the user how many of the mandatory events they've attended. There should also be a list of the next 5 upcoming events.