### PR TITLE
Added functionality to unapprove service hours

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -68,6 +68,12 @@ class ServicesController < ApplicationController
     redirect_to(services_path)
   end
 
+  def unapprove
+    @service = Service.find(params[:id])
+    @service.update(isApproved: false)
+    redirect_to(services_path)
+  end
+
   private
 
   def service_params

--- a/app/views/services/_tableApproved.html.erb
+++ b/app/views/services/_tableApproved.html.erb
@@ -24,6 +24,7 @@
         </td>
         <td><%= image_tag service.approved_img_path, height: 30, alt: "approved checkmark", class: "check" %></td>
         <td>
+          <div><%= button_to 'Unapprove', {:controller => "services", :class => "btn btn-primary", :action => "unapprove", :id => service.id}, {:method=>:post}%></div>
           <div><%= link_to("Details", service_path(service), :class => 'action show') %></div>
           <div><%= link_to("Edit", edit_service_path(service), :class => 'action edit') %></div>
           <div><%= link_to("Delete", delete_service_path(service), :class => 'action delete') %></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     member do
       get :delete
       post :approve
+      post :unapprove
     end
   end
 


### PR DESCRIPTION
Added action to service controller "unapprove". Added this action to routes.rb, and modified the approvedTable view accordingly.

I tested it on localhost by creating a service hour and then logging in with an admin account and making sure it could be approved and unapproved.

Tested my code with rubocop.