### PR TITLE
Fixed minor view issues and number of upcoming events shown for members

### DIFF
--- a/app/controllers/point_tracker_controller.rb
+++ b/app/controllers/point_tracker_controller.rb
@@ -7,7 +7,7 @@ class PointTrackerController < ApplicationController
                                                                                        Time.zone.now).length
 
     ordered = Event.order(:datetime)
-    @upcoming_events = ordered.where('datetime > ? or datetime IS NULL', Time.zone.now).limit(5)
+    @upcoming_events = ordered.where('datetime > ? or datetime IS NULL', Time.zone.now)
     @service_hours = Service.where(member_id: current_member.id).order('date desc')
   end
 

--- a/app/views/point_tracker/admin.html.erb
+++ b/app/views/point_tracker/admin.html.erb
@@ -238,12 +238,11 @@
   </style>
     <% content_for(:html_title) { 'Points Tracker' } %>
 
-    <h1>You're logged in to Admin View! Welcome, <%= current_member.name%></h1>
-
     <!-- <%= link_to("Home", {controller: "home", action: "index"}) %> -->
     <br/>
 
     <div class="mt-5 container home index">
+    <h2 class="center">Welcome to Admin View, <%= current_member.name%></h2><br>
       <table id="ParticipationTable" class="table table-striped">
         <h1>Member Participation:</h1>
           <tr>

--- a/app/views/point_tracker/tracker.html.erb
+++ b/app/views/point_tracker/tracker.html.erb
@@ -42,11 +42,14 @@
   <body>
     <%= flash[:alert] %>
     <% content_for(:html_title) { 'Points Tracker' } %>
+
     <div class="container mt-5 events show">
+    <h2 class="center">Welcome To The Member Home Page, <%= current_member.name%></h2><br><br><br>
       <div class="row">
         <div class="col left">
           <table class="table table-striped" summary="Event detail view">
-            <h1 style="margin-bottom: 4rem">Events: <%= @member_mandatory_event_num %> / <%=@mandatory_event_num %> mandatory events attended</h1>            
+            <h1>Event Participation: <%= @member_mandatory_event_num %> / <%=@mandatory_event_num %></h1>  
+            <h2>Upcoming Events</h2>       
             <thead>
               <tr>
                 <th>Name</th>
@@ -55,7 +58,7 @@
               </tr>
             </thead>  
             <tbody>
-              <% @current_member.events.each do |event| %>
+              <% @upcoming_events.each do |event| %>
                 <tr>
                   <td><%= event.name %></td>
                   <td><%= event.format_date %></td>
@@ -67,8 +70,8 @@
         </div>
         <div class="col right">
           <table class="table table-striped" summary="Event detail view">            
-          <h1> Service Hours: <%= @service_hours.where(isApproved: true).sum(:hours) %> approved</h1>
-          <p>(<%= @service_hours.where(isApproved: true).sum(:hours) %> approved)</p>
+          <h1>Approved Service Hours: <%= @service_hours.where(isApproved: true).sum(:hours) %></h1>
+          <h2>Service Hours</h2>    
             <thead>
               <tr>
                 <th>Description</th>


### PR DESCRIPTION
"Admin view and user view seem somewhat similar and it's not immediately apparent if you're logged in as admin or normal user"
Tried to make the two a little more differentiated by changing the welcome message upon login

"We need to be able to see more than the next 5 events. Perhaps a show more button. This is definitely a bigger issue"
Took away the limit on events and made it upcoming events (think tejas changed this by accident when implementing visual changes)